### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.11.1
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.11.1
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ I find joy in seeing the code I write come alive in one way or another — wheth
 ### 🛠 I'm using...
 
 - Python (in 6 projects)
-- TypeScript (in 5 projects)
+- TypeScript (in 4 projects)
 - JavaScript (in 3 projects)
 - Swift (in 2 projects)
-- HTML (in 2 projects)
+- C# (in 2 projects)
 - Go (in 1 project)
-- C# (in 1 project)
 - Shell (in 1 project)
+- HTML (in 1 project)
 - Svelte (in 1 project)
 - Vue (in 1 project)
 - Ruby (in 1 project)
 - SCSS (in 1 project)
 
-<sub>Last updated: 04 December 2022</sub>
+<sub>Last updated: 18 January 2023</sub>
 
 ---
 

--- a/update/.cache
+++ b/update/.cache
@@ -1,11 +1,11 @@
 Python,6
-TypeScript,5
+TypeScript,4
 JavaScript,3
 Swift,2
-HTML,2
+C#,2
 Go,1
-C#,1
 Shell,1
+HTML,1
 Svelte,1
 Vue,1
 Ruby,1


### PR DESCRIPTION
The workflow has been broken since sometime in mid-December after two things happened:

- The Actions runners on GitHub stopped supporting Python 3.6; and
- The personal access tokens used to access private repos (and therefore is required) had expired sometime in early January.

This pull request fixes the first point by upgrading the Python version to 3.11.1. A new PAT is also generated and stored as a secret in the repository.