### PR TITLE
Upgrade Actions

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11.1
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11.1
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This PR upgrades the [`checkout`](https://github.com/marketplace/actions/checkout) and [`setup-python`](https://github.com/marketplace/actions/setup-python) actions to the latest versions (v2 to v4 and v2 to v5 respectively). No more warnings about deprecated Node versions! 🥳 